### PR TITLE
changed entrypoint in signal Dockerfile

### DIFF
--- a/signal/Dockerfile
+++ b/signal/Dockerfile
@@ -1,5 +1,5 @@
 FROM bbernhard/signal-cli-rest-api:latest
 
-ENTRYPOINT ["main", "-signal-cli-config", "/data/"]
+ENTRYPOINT ["signal-cli-rest-api", "-signal-cli-config", "/data/"]
 
 VOLUME ["/share", "/ssl", "/data"]


### PR DESCRIPTION
The name of the signal-cli-rest-api binary was recently changed from "main" to
"signal-cli-rest-api". So in order to make the HA addon work again,
this also needs to be changed here.

This should fix this issue here: https://github.com/haberda/hassio_addons/issues/2